### PR TITLE
Allow test guilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
-.direnv/
 __pycache__/
 *.db
+.direnv/
+.venv/

--- a/tinymod/__main__.py
+++ b/tinymod/__main__.py
@@ -9,11 +9,12 @@ from hata.ext.slash import setup_ext_slash
 import os
 
 # Presetup some stuff
-GUILD = Guild.precreate(1068976834382925865)
-ADMIN_ROLE = Role.precreate(1068980562477465670)
+assert (TOKEN := os.getenv("TOKEN")), 'Environment variable "TOKEN" not found. Add it to your local .env file.'
+GUILD = Guild.precreate(os.getenv("GUILD_ID", 1068976834382925865))
+ADMIN_ROLE = Role.precreate(os.getenv("ADMIN_ROLE_ID", 1068980562477465670))
 
 # Create bot
-TinyMod = Client(os.environ["TOKEN"], activity=Activity("you...", activity_type=ActivityType.watching))
+TinyMod = Client(TOKEN, activity=Activity("you...", activity_type=ActivityType.watching))
 slash = setup_ext_slash(TinyMod, use_default_exception_handler=False)
 
 @TinyMod.events


### PR DESCRIPTION
Wasn't able to test previous change due to the guild id being hard coded. Would be nice to be able to join it to a test server with a test bot. 
BUT left all the default hard-coded id's for guild, admin role so there is no changes to how you start the bot on your end.
Oh and .venv to the .gitignore didn't understand what ".direnv" was until I pushed this. Sorry about that, can remove it if you want but just left it in-case there are any other ".venv" enjoyers who decide to make a pr.